### PR TITLE
Issue #3 : Pysam Compatibility issue, pysam.csamfile.Samfile has no o…

### DIFF
--- a/HTSeq/__init__.py
+++ b/HTSeq/__init__.py
@@ -974,7 +974,7 @@ class BAM_Reader( object ):
            raise TypeError, "Use a HTSeq.GenomicInterval to access regions within .bam-file!"        
         if self.sf is None:
            self.sf = pysam.Samfile( self.filename, "rb" )
-           if not self.sf._hasIndex():
+           if not self.sf.has_index():
               raise ValueError, "The .bam-file has no index, random-access is disabled!"
         for pa in self.sf.fetch( iv.chrom, iv.start+1, iv.end ):
             yield SAM_Alignment.from_pysam_AlignedRead( pa, self.sf )

--- a/HTSeq/__init__.py
+++ b/HTSeq/__init__.py
@@ -974,8 +974,12 @@ class BAM_Reader( object ):
            raise TypeError, "Use a HTSeq.GenomicInterval to access regions within .bam-file!"        
         if self.sf is None:
            self.sf = pysam.Samfile( self.filename, "rb" )
-           if not self.sf.has_index():
-              raise ValueError, "The .bam-file has no index, random-access is disabled!"
+           try:
+             if not self.sf.has_index():
+               raise ValueError, "The .bam-file has no index, random-access is disabled!"
+           except AttributeError:
+             if not self.sf._hasIndex():
+               raise ValueError, "The .bam-file has no index, random-access is disabled!"
         for pa in self.sf.fetch( iv.chrom, iv.start+1, iv.end ):
             yield SAM_Alignment.from_pysam_AlignedRead( pa, self.sf )
     


### PR DESCRIPTION
The `_hasIndex()` call in the `__init__.py` script is broken due to changes in the `pysam.csamfile.Samfile` object in `pysam version >0.8.3` which has renamed this function to has_index(). 
