### PR TITLE
Initial attempt to add Py3 support for HTSeq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+HTSeq.egg-info
+build
+dist
+HTSeq/StepVector.py
+HTSeq/_version.py
+src/_HTSeq.c
+src/StepVector_wrap.cxx

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ HTSeq/StepVector.py
 HTSeq/_version.py
 src/_HTSeq.c
 src/StepVector_wrap.cxx
+*/*.bak
+HTSeq/__pycache__/
+example_data/minus.wig
+example_data/plus.wig
+example_data/region.bam
+example_data/test.fa
+example_data/test.fq

--- a/HTSeq/_HTSeq_internal.py
+++ b/HTSeq/_HTSeq_internal.py
@@ -3,20 +3,20 @@ import itertools
 import numpy
 
 def GenomicInterval_xrange( gi, step ):
-   for pos in xrange( gi.start, gi.end, step ):
+   for pos in range( gi.start, gi.end, step ):
       yield HTSeq.GenomicPosition( gi.chrom, pos, gi.strand )
       
 def GenomicInterval_xranged( gi, step ):
    if gi.strand == "-":
       step *= -1
-   for pos in xrange( gi.start_d, gi.end_d, step ):
+   for pos in range( gi.start_d, gi.end_d, step ):
       yield HTSeq.GenomicPosition( gi.chrom, pos, gi.strand ) 
                    
 def ChromVector_steps( cv ):
    if isinstance( cv.array, numpy.ndarray ):
       start = cv.iv.start
       prev_val = None
-      for i in xrange( cv.iv.start, cv.iv.end ):
+      for i in range( cv.iv.start, cv.iv.end ):
          val = cv.array[ i - cv.offset ]
          if prev_val is None or val != prev_val:
             if prev_val is not None:
@@ -28,11 +28,11 @@ def ChromVector_steps( cv ):
       for start, stop, value in cv.array[cv.iv.start:cv.iv.end].get_steps():
          yield ( HTSeq.GenomicInterval( cv.iv.chrom, start, stop, cv.iv.strand ), value )
    else:
-      raise SystemError, "Unknown array type."
+      raise SystemError("Unknown array type.")
       
 def GenomicArray_steps( ga ):
-   for a in ga.chrom_vectors.values():
-      for cv in a.values():
+   for a in list(ga.chrom_vectors.values()):
+      for cv in list(a.values()):
          for iv, val in cv.steps():
             yield iv, val
 

--- a/HTSeq/__init__.py
+++ b/HTSeq/__init__.py
@@ -7,6 +7,7 @@ import itertools, warnings, os, shlex
 import sys
 
 try:
+   import HTSeq
    from HTSeq._HTSeq import *
    #from _HTSeq import *
 except ImportError:
@@ -15,7 +16,7 @@ except ImportError:
    else:
       raise
       
-from _version import __version__
+from HTSeq._version import __version__
 
 #from vcf_reader import *
 

--- a/HTSeq/__init__.py
+++ b/HTSeq/__init__.py
@@ -4,9 +4,11 @@ See http://www-huber.embl.de/users/anders/HTSeq for documentation.
 """
 
 import itertools, warnings, os, shlex
+import sys
 
 try:
-   from _HTSeq import *
+   from HTSeq._HTSeq import *
+   #from _HTSeq import *
 except ImportError:
    if os.path.isfile( "setup.py" ):
       raise ImportError( "Cannot import 'HTSeq' when working directory is HTSeq's own build directory.")
@@ -95,7 +97,7 @@ class GenomicFeature( object ):
    
    def __init__( self, name, type_, interval ):
       self.name = name
-      self.type = intern( type_ )
+      self.type = sys.intern( type_ )
       self.iv = interval
       
    def __repr__( self ):
@@ -154,19 +156,19 @@ def parse_GFF_attribute_string( attrStr, extra_return_first_value=False ):
       attrStr = attrStr[:-1]
    d = {}
    first_val = "_unnamed_"
-   for (i, attr) in itertools.izip( itertools.count(), _HTSeq.quotesafe_split( attrStr ) ):
+   for (i, attr) in zip( itertools.count(), _HTSeq.quotesafe_split( attrStr ) ):
       if _re_attr_empty.match( attr ):
          continue
       if attr.count( '"' ) not in ( 0, 2 ):
-         raise ValueError, "The attribute string seems to contain mismatched quotes."
+         raise ValueError("The attribute string seems to contain mismatched quotes.")
       mo = _re_attr_main.match( attr )
       if not mo:
-         raise ValueError, "Failure parsing GFF attribute line"
+         raise ValueError("Failure parsing GFF attribute line")
       val = mo.group(2)
       if val.startswith( '"' ) and val.endswith( '"' ):
          val = val[1:-1]
       #val = urllib.unquote( val )
-      d[ intern(mo.group(1)) ] = intern(val)
+      d[ sys.intern(mo.group(1)) ] = sys.intern(val)
       if extra_return_first_value and i == 0:
          first_val = val         
    if extra_return_first_value:
@@ -327,8 +329,8 @@ class FastaReader( FileOrSequence ):
    def build_index( self, force = False ):
       self._import_pysam()
       if not isinstance( self.fos, str ):
-         raise TypeError, "This function only works with FastaReader objects " + \
-            "connected to a fasta file via file name"
+         raise TypeError("This function only works with FastaReader objects " + \
+            "connected to a fasta file via file name")
       index_filename = self.fos + ".fai"
       if os.access( index_filename, os.R_OK ):
          if (not force) and os.stat( self.filename_or_sequence ).st_mtime <= \
@@ -337,14 +339,14 @@ class FastaReader( FileOrSequence ):
             return
       pysam.faidx( self.fos )
       if not os.access( index_filename, os.R_OK ):
-         raise SystemError, "Building of Fasta index failed due to unknown error."
+         raise SystemError("Building of Fasta index failed due to unknown error.")
       
    def __getitem__( self, iv ):
       if not isinstance( iv, GenomicInterval ):
-         raise TypeError, "GenomicInterval expected as key."
+         raise TypeError("GenomicInterval expected as key.")
       if not isinstance( self.fos, str ):
-         raise TypeError, "This function only works with FastaReader objects " + \
-            "connected to a fasta file via file name"
+         raise TypeError("This function only works with FastaReader objects " + \
+            "connected to a fasta file via file name")
       self._import_pysam()
       fasta = pysam.faidx( self.fos, "%s:%d-%d" % ( iv.chrom, iv.start, iv.end-1 ) )
       ans = list( FastaReader( fasta ) )
@@ -366,15 +368,15 @@ class FastqReader( FileOrSequence ):
       FileOrSequence.__init__( self, file_ )
       self.qual_scale = qual_scale
       if qual_scale not in ( "phred", "solexa", "solexa-old" ):
-         raise ValueError, "Illegal quality scale."
+         raise ValueError("Illegal quality scale.")
       
    def __iter__( self ):
       fin = FileOrSequence.__iter__( self )
       while True:
-         id1  = fin.next()
-         seq  = fin.next()
-         id2  = fin.next()
-         qual = fin.next()
+         id1  = next(fin)
+         seq  = next(fin)
+         id2  = next(fin)
+         qual = next(fin)
          if qual == "":
             if id1 != "":
                warnings.warn( "Number of lines in FASTQ file is not "
@@ -421,7 +423,7 @@ def bundle_multiple_alignments( sequence_of_alignments ):
    returns an iterator over these.
    """
    alignment_iter = iter( sequence_of_alignments )
-   algnt = alignment_iter.next()
+   algnt = next(alignment_iter)
    ma = [ algnt ]
    for algnt in alignment_iter:
       if algnt.read.name != ma[0].read.name:
@@ -502,7 +504,7 @@ class SolexaExportReader( FileOrSequence ):
          elif fields['passed_filtering'] == 'N':
             record.passed_filter = False
          else:
-            raise ValueError, "Illegal 'passed filter' value in Solexa export data: '%s'." % fields['passed_filtering']
+            raise ValueError("Illegal 'passed filter' value in Solexa export data: '%s'." % fields['passed_filtering'])
          record.index_string = fields['index_string']
          if fields['pos'] == '':
             record.iv = None
@@ -513,7 +515,7 @@ class SolexaExportReader( FileOrSequence ):
             elif fields['strand'] == 'R':
                strand = '-'
             else:
-               raise ValueError, "Illegal strand value in Solexa export data."
+               raise ValueError("Illegal strand value in Solexa export data.")
             start = int( fields['pos'] )
             chrom = fields['chrom']
             if fields['chrom'] == "":
@@ -534,7 +536,7 @@ class SAM_Reader( FileOrSequence ):
             continue
          try:
             algnt = SAM_Alignment.from_SAM_line( line )
-         except ValueError, e:
+         except ValueError as e:
             e.args = e.args + ( self.get_line_number_string(), )
             raise
          yield algnt
@@ -551,9 +553,9 @@ class GenomicArrayOfSets( GenomicArray ):
    def __init__( self, chroms, stranded=True, storage='step', memmap_dir = "" ):
       GenomicArray.__init__( self, chroms, stranded, 'O', storage, memmap_dir )
 
-   def add_chrom( self, chrom, length = sys.maxint, start_index = 0 ):
+   def add_chrom( self, chrom, length = sys.maxsize, start_index = 0 ):
       GenomicArray.add_chrom( self, chrom, length, start_index )
-      for cv in self.chrom_vectors[ chrom ].values():
+      for cv in list(self.chrom_vectors[ chrom ].values()):
          cv[:] = set()
          cv.is_vector_of_sets = True
       
@@ -600,9 +602,9 @@ def pair_SAM_alignments( alignments, bundle=False ):
    current_name = None
    for almnt in alignments:
       if not almnt.paired_end:
-         raise ValueError, "'pair_alignments' needs a sequence of paired-end alignments"
+         raise ValueError("'pair_alignments' needs a sequence of paired-end alignments")
       if almnt.pe_which == "unknown":
-         raise ValueError, "Paired-end read found with 'unknown' 'pe_which' status."
+         raise ValueError("Paired-end read found with 'unknown' 'pe_which' status.")
       if almnt.read.name == current_name:
          almnt_list.append( almnt )
       else:
@@ -629,9 +631,9 @@ def pair_SAM_alignments_with_buffer( alignments, max_buffer_size=3000000 ):
    for almnt in alignments:
 
       if not almnt.paired_end:
-         raise ValueError, "Sequence of paired-end alignments expected, but got single-end alignment."
+         raise ValueError("Sequence of paired-end alignments expected, but got single-end alignment.")
       if almnt.pe_which == "unknown":
-         raise ValueError, "Cannot process paired-end alignment found with 'unknown' 'pe_which' status."
+         raise ValueError("Cannot process paired-end alignment found with 'unknown' 'pe_which' status.")
 
       matekey = ( 
          almnt.read.name, 
@@ -668,12 +670,12 @@ def pair_SAM_alignments_with_buffer( alignments, max_buffer_size=3000000 ):
          else:
             almnt_buffer[ almntkey ].append( almnt )
          if len(almnt_buffer) > max_buffer_size:
-            raise ValueError, "Maximum alignment buffer size exceeded while pairing SAM alignments."
+            raise ValueError("Maximum alignment buffer size exceeded while pairing SAM alignments.")
 
    if len(almnt_buffer) > 0:
       warnings.warn( "Mate records missing for %d records; first such record: %s." % 
-         ( len(almnt_buffer), str( almnt_buffer.values()[0][0] ) ) )
-      for almnt_list in almnt_buffer.values():
+         ( len(almnt_buffer), str( list(almnt_buffer.values())[0][0] ) ) )
+      for almnt_list in list(almnt_buffer.values()):
          for almnt in almnt_list:
             if almnt.pe_which == "first":
                yield ( almnt, None )
@@ -742,7 +744,7 @@ class VariantCall( object ):
             ret.samples = {}
             spos=9
             for sid in sampleids:
-                ret.samples[ sid ] = dict( ( name, value ) for (name, value) in itertools.izip( ret.format, lsplit[spos].split(":") ) )
+                ret.samples[ sid ] = dict( ( name, value ) for (name, value) in zip( ret.format, lsplit[spos].split(":") ) )
                 spos += 1
         ret.pos = GenomicPosition( ret.chrom, int(ret.pos) )
         ret.alt = ret.alt.split(",")
@@ -761,7 +763,7 @@ class VariantCall( object ):
     
     def sampleline( self ):
        if self.format == None:
-          print >> sys.stderr, "No samples in this variant call!" 
+          print("No samples in this variant call!", file=sys.stderr) 
           return ""
        keys = self.format
        ret = [ ":".join( keys ) ]
@@ -790,8 +792,8 @@ class VariantCall( object ):
         for token in self.info.strip(";").split(";"):
             if re.compile("=").search(token):
                 token = token.split("=")
-                if infodict.has_key( token[0] ):
-                    tmp[token[0]] = map( infodict[token[0]], token[1].split(",") )
+                if token[0] in infodict:
+                    tmp[token[0]] = list(map( infodict[token[0]], token[1].split(",") ))
                 else:
                     tmp[token[0]] = token[1].split(",")
                 if len( tmp[ token[0] ] ) == 1:
@@ -816,7 +818,7 @@ class VCF_Reader( FileOrSequence ):
         self.sampleids = []
         
     def make_info_dict( self ):
-        self.infodict = dict( ( key, _vcf_typemap[self.info[key]["Type"]] ) for key in self.info.keys() )
+        self.infodict = dict( ( key, _vcf_typemap[self.info[key]["Type"]] ) for key in list(self.info.keys()) )
     
     def parse_meta( self, header_filename = None ):
         if header_filename == None:
@@ -915,7 +917,7 @@ class WiggleReader( FileOrSequence ):
                     span = 1
             elif line.startswith( 'browser' ) or line.startswith( '#' ): #Comment or ignored
                 if self.verbose:
-                    print "Ignored line:", line
+                    print("Ignored line:", line)
                 continue
             else:
                 if self.stepType == 'fixed':
@@ -956,8 +958,8 @@ class BAM_Reader( object ):
               self.record_no += 1
         except ValueError as e:
            if e.message == "fetch called on bamfile without index":
-              print "Error: ", e.message
-              print "Your bam index file is missing or wrongly named, convention is that file 'x.bam' has index file 'x.bam.bai'!"
+              print("Error: ", e.message)
+              print("Your bam index file is missing or wrongly named, convention is that file 'x.bam' has index file 'x.bam.bai'!")
            else:
               raise
         except:
@@ -971,11 +973,11 @@ class BAM_Reader( object ):
     
     def __getitem__( self, iv ):
         if not isinstance( iv, GenomicInterval ):
-           raise TypeError, "Use a HTSeq.GenomicInterval to access regions within .bam-file!"        
+           raise TypeError("Use a HTSeq.GenomicInterval to access regions within .bam-file!")        
         if self.sf is None:
            self.sf = pysam.Samfile( self.filename, "rb" )
            if not self.sf._hasIndex():
-              raise ValueError, "The .bam-file has no index, random-access is disabled!"
+              raise ValueError("The .bam-file has no index, random-access is disabled!")
         for pa in self.sf.fetch( iv.chrom, iv.start+1, iv.end ):
             yield SAM_Alignment.from_pysam_AlignedRead( pa, self.sf )
     
@@ -1023,9 +1025,9 @@ class BED_Reader( FileOrSequence ):
             continue
          fields = line.split()
          if len(fields) < 3:
-            raise ValueError, "BED file line contains less than 3 fields"
+            raise ValueError("BED file line contains less than 3 fields")
          if len(fields) > 9:
-            raise ValueError, "BED file line contains more than 9 fields"
+            raise ValueError("BED file line contains more than 9 fields")
          iv = GenomicInterval( fields[0], int(fields[1]), int(fields[2]), fields[5] if len(fields) > 5 else "." )
          f = GenomicFeature( fields[3] if len(fields) > 3 else "unnamed", "BED line", iv )
          f.score = float( fields[4] ) if len(fields) > 4 else None

--- a/HTSeq/__init__.py
+++ b/HTSeq/__init__.py
@@ -198,10 +198,12 @@ class GFF_Reader( FileOrSequence ):
    
    def __iter__( self ):
       for line in FileOrSequence.__iter__( self ):
+         line = bytes(line, encoding="UTF-8")
+         
          if line == "\n":
             continue
-         if line.startswith( '#' ):
-            if line.startswith( "##" ):
+         if line.startswith( b'#' ):
+            if line.startswith( b"##" ):
                mo = _re_gff_meta_comment.match( line )
                if mo:
                   self.metadata[ mo.group(1) ] = mo.group(2)
@@ -764,7 +766,7 @@ class VariantCall( object ):
     
     def sampleline( self ):
        if self.format == None:
-          print("No samples in this variant call!", file=sys.stderr) 
+          sys.stderr.write("No samples in this variant call!\n") 
           return ""
        keys = self.format
        ret = [ ":".join( keys ) ]

--- a/HTSeq/scripts/count.py
+++ b/HTSeq/scripts/count.py
@@ -12,7 +12,7 @@ def invert_strand( iv ):
    elif iv2.strand == "-":
       iv2.strand = "+"
    else:
-      raise ValueError, "Illegal strand"
+      raise ValueError("Illegal strand")
    return iv2
 
 def count_reads_in_features( sam_filename, gff_filename, samtype, order, stranded, 
@@ -49,12 +49,12 @@ def count_reads_in_features( sam_filename, gff_filename, samtype, order, strande
             try:
                feature_id = f.attr[ id_attribute ]
             except KeyError:
-               raise ValueError, ( "Feature %s does not contain a '%s' attribute" % 
-                  ( f.name, id_attribute ) )
+               raise ValueError( "Feature %s does not contain a '%s' attribute" % 
+                  ( f.name, id_attribute ))
             if stranded != "no" and f.iv.strand == ".":
-               raise ValueError, ( "Feature %s at %s does not have strand information but you are "
+               raise ValueError( "Feature %s at %s does not have strand information but you are "
                   "running htseq-count in stranded mode. Use '--stranded=no'." % 
-                  ( f.name, f.iv ) )
+                  ( f.name, f.iv ))
             features[ f.iv ] += feature_id
             counts[ f.attr[ id_attribute ] ] = 0
          i += 1
@@ -75,17 +75,17 @@ def count_reads_in_features( sam_filename, gff_filename, samtype, order, strande
    elif samtype == "bam":
       SAM_or_BAM_Reader = HTSeq.BAM_Reader
    else:
-      raise ValueError, "Unknown input format %s specified." % samtype
+      raise ValueError("Unknown input format %s specified." % samtype)
 
    try:
       if sam_filename != "-":
          read_seq_file = SAM_or_BAM_Reader( sam_filename )
          read_seq = read_seq_file
-         first_read = iter(read_seq).next()
+         first_read = next(iter(read_seq))
       else:
          read_seq_file = SAM_or_BAM_Reader( sys.stdin )
          read_seq_iter = iter( read_seq_file )
-         first_read = read_seq_iter.next()
+         first_read = next(read_seq_iter)
          read_seq = itertools.chain( [ first_read ], read_seq_iter )
       pe_mode = first_read.paired_end
    except:
@@ -99,7 +99,7 @@ def count_reads_in_features( sam_filename, gff_filename, samtype, order, strande
          elif order == "pos":
             read_seq = HTSeq.pair_SAM_alignments_with_buffer( read_seq )
          else:
-            raise ValueError, "Illegal order specified."
+            raise ValueError("Illegal order specified.")
       empty = 0
       ambiguous = 0
       notaligned = 0
@@ -209,12 +209,12 @@ def count_reads_in_features( sam_filename, gff_filename, samtype, order, strande
       samoutfile.close()
 
    for fn in sorted( counts.keys() ):
-      print "%s\t%d" % ( fn, counts[fn] )
-   print "__no_feature\t%d" % empty
-   print "__ambiguous\t%d" % ambiguous
-   print "__too_low_aQual\t%d" % lowqual
-   print "__not_aligned\t%d" % notaligned
-   print "__alignment_not_unique\t%d" % nonunique
+      print("%s\t%d" % ( fn, counts[fn] ))
+   print("__no_feature\t%d" % empty)
+   print("__ambiguous\t%d" % ambiguous)
+   print("__too_low_aQual\t%d" % lowqual)
+   print("__not_aligned\t%d" % notaligned)
+   print("__alignment_not_unique\t%d" % nonunique)
 
       
 def main():

--- a/build_it
+++ b/build_it
@@ -2,5 +2,12 @@
 
 (cd src; make)
 echo __version__ = \"`cat VERSION`\" > HTSeq/_version.py
-python3 setup.py build
-#python2 setup.py build
+
+if command -v python2; then
+	python2 setup.py build
+fi
+
+if command -v python3; then
+	python3 setup.py build
+fi
+

--- a/build_it
+++ b/build_it
@@ -2,4 +2,5 @@
 
 (cd src; make)
 echo __version__ = \"`cat VERSION`\" > HTSeq/_version.py
-python setup.py build
+python3 setup.py build
+#python2 setup.py build

--- a/doc/tour.rst
+++ b/doc/tour.rst
@@ -67,7 +67,7 @@ reads.
 
    >>> import itertools
    >>> for read in itertools.islice( fastq_file, 10 ):
-   ...    print read
+   ...    print(read)
    CTTACGTTTTCTGTATCAATACTCGATTTATCATCT
    AATTGGTTTCCCCGCCGAGACCGTACACTACCAGCC
    TTTGGACTTGATTGTTGACGCTATCAAGGCTGCTGG
@@ -445,7 +445,7 @@ form the set union of the three reported sets, using Python's set union operator
    >>> fset = set()
    >>> for iv, val in gas[ read_iv ].steps():
    ...    fset |= val
-   >>> print fset
+   >>> print(fset)
    set(['A', 'B'])
 
 Experienced Python developers will recognize that the ``for`` loop can be replaced with a single line

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ if sys.version_info[0] < 2 and sys.version_info[1] < 5:
    sys.stderr.write( "You need at least version 2.5 of Python to use HTSeq.\n" )
    sys.exit( 1 )
 
-if sys.version_info[0] >= 3:
-   sys.stderr.write( "Error in setup script for HTSeq:\n" )
-   sys.stderr.write( "Sorry, this package does not yet work with Python 3.\n" )
-   sys.stderr.write( "Please use Python 2.x, x>=5.\n" )
-   sys.exit( 1 )
+#if sys.version_info[0] >= 3:
+#   sys.stderr.write( "Error in setup script for HTSeq:\n" )
+#   sys.stderr.write( "Sorry, this package does not yet work with Python 3.\n" )
+#   sys.stderr.write( "Please use Python 2.x, x>=5.\n" )
+#   sys.exit( 1 )
 
 try:
    import numpy
@@ -28,10 +28,15 @@ except ImportError:
    sys.exit( 1 )
    
 numpy_include_dir = os.path.join( os.path.dirname( numpy.__file__ ), 'core', 'include' )
- 
+
+
+def get_version():
+    with open("VERSION","r") as fh:
+        return fh.read().strip().strip('%')
+
 
 setup( name = 'HTSeq',
-       version = file("VERSION").readline().rstrip(),
+       version = get_version(),
        author = 'Simon Anders',
        author_email = 'sanders@fs.tum.de',
        url = 'http://www-huber.embl.de/users/anders/HTSeq/',

--- a/src/HTSeq/_HTSeq.pyx
+++ b/src/HTSeq/_HTSeq.pyx
@@ -1305,7 +1305,7 @@ cdef class SAM_Alignment( AlignmentWithSequenceReversal ):
           iv = GenomicInterval( chrom, read.reference_start, read.reference_end, strand )
       else:
           iv = None
-      seq = SequenceWithQualities( read.query_sequence, read.query_name, '', "noquals" )
+      seq = SequenceWithQualities(bytes(read.query_sequence,encoding="UTF-8"), read.query_name, b'', 'noquals')
       if read.query_qualities != None:
           seq.qual = numpy.array(read.query_qualities)
       a = SAM_Alignment( seq, iv )
@@ -1375,9 +1375,9 @@ cdef class SAM_Alignment( AlignmentWithSequenceReversal ):
          iv = GenomicInterval( rname, posint, cigarlist[-1].ref_iv.end, strand )   
             
       if qual != "*":
-         swq = SequenceWithQualities( seq.upper(), qname, qual )
+         swq = SequenceWithQualities( bytes(seq.upper(),encoding="UTF-8"), qname, bytes(seq.upper(),encoding="UTF-8") )
       else:
-         swq = SequenceWithQualities( seq.upper(), qname, "", "noquals" )
+         swq = SequenceWithQualities( bytes(seq.upper(),encoding="UTF-8"), qname, "", "noquals" )
 
       alnmt = SAM_Alignment( swq, iv )
       alnmt.flag = flagint   

--- a/src/HTSeq/_HTSeq.pyx
+++ b/src/HTSeq/_HTSeq.pyx
@@ -6,13 +6,16 @@ import csv
 import gzip
 import itertools 
 import collections
-import cStringIO
+try:
+    import cStringIO
+except:
+    pass
 import warnings
 import numpy
 cimport numpy
 
-import StepVector
-import _HTSeq_internal
+from HTSeq import StepVector
+from HTSeq import _HTSeq_internal
 
 
 ###########################
@@ -84,11 +87,11 @@ cdef class GenomicInterval:
    def __repr__( GenomicInterval self ):
       return "<%s object '%s', [%d,%s), strand '%s'>" % \
          ( self.__class__.__name__, self.chrom, self.start, 
-           str(self.end) if self.end != sys.maxint else "Inf", self.strand )
+           str(self.end) if self.end != sys.maxsize else "Inf", self.strand )
          
    def __str__( GenomicInterval self ):
          return "%s:[%d,%s)/%s" % \
-            ( self.chrom, self.start, str(self.end) if self.end != sys.maxint else "Inf", self.strand )
+            ( self.chrom, self.start, str(self.end) if self.end != sys.maxsize else "Inf", self.strand )
 
    property length:
 
@@ -499,7 +502,7 @@ cdef class GenomicArray( object ):
          if storage != 'step':
             raise TypeError, "Indefinite-length chromosomes can " + \
                " only be used with storage type 'StepVector'."
-         chroms = dict( [ ( c, sys.maxint ) for c in chroms ] )
+         chroms = dict( [ ( c, sys.maxsize ) for c in chroms ] )
       elif not isinstance( chroms, dict ):
          raise TypeError, "'chroms' must be a list or a dict or 'auto'."
       self.storage = storage
@@ -550,10 +553,10 @@ cdef class GenomicArray( object ):
       else:
          raise TypeError, "Illegal index type."
             
-   def add_chrom( self, chrom, length = sys.maxint, start_index = 0 ):
+   def add_chrom( self, chrom, length = sys.maxsize, start_index = 0 ):
       cdef GenomicInterval iv 
-      if length == sys.maxint:
-         iv = GenomicInterval( chrom, start_index, sys.maxint, "." )
+      if length == sys.maxsize:
+         iv = GenomicInterval( chrom, start_index, sys.maxsize, "." )
       else:
          iv = GenomicInterval( chrom, start_index, start_index + length, "." )
       if self.stranded:
@@ -587,7 +590,7 @@ cdef class GenomicArray( object ):
          f.write( "track type=bedGraph %s\n" % track_options )
       for chrom in self.chrom_vectors:
          for iv, value in self.chrom_vectors[ chrom ][ strand ].steps():
-            if iv.start == -sys.maxint-1 or iv.end == sys.maxint:
+            if iv.start == -sys.maxsize-1 or iv.end == sys.maxsize:
                continue
             f.write( "%s\t%d\t%d\t%f\n" % (iv.chrom, iv.start, iv.end, value) )    
       if not hasattr( file_or_filename, "write" ):
@@ -619,7 +622,7 @@ def _make_translation_table_for_complementation( ):
    t[ ord('t') ] = 'a'
    t[ ord('c') ] = 'g'
    t[ ord('g') ] = 'c'
-   return ''.join( t )
+   return bytes(''.join( t ),encoding="UTF-8")
    
 cdef bytes _translation_table_for_complementation = _make_translation_table_for_complementation( )
 
@@ -687,15 +690,15 @@ cdef class Sequence( object ):
       cdef char* seq_cstr = self.seq
       for i in xrange( seq_length ):
          b = seq_cstr[i]
-         if b == 'A' or b == 'a':
+         if b in [b'A', b'a']:
             count_array[ i, 0 ] += 1
-         elif b == 'C' or b == 'c':
+         elif b in [b'C', b'c']:
             count_array[ i, 1 ] += 1
-         elif b == 'G' or b == 'g':
+         elif b in [b'G', b'g']:
             count_array[ i, 2 ] += 1
-         elif b == 'T' or b == 't':
+         elif b in [b'T', b't']:
             count_array[ i, 3 ] += 1
-         elif b == 'N' or b == 'n' or b == ".":
+         elif b in [b'N', b'n', b'.']:
             count_array[ i, 4 ] += 1
          else:
             raise ValueError, "Illegal base letter encountered."

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,9 +7,13 @@ clean:
 	rm -f StepVector_wrap.cxx ../HTSeq/StepVector.py _HTSeq.c
    
 _HTSeq.c: HTSeq/_HTSeq.pyx HTSeq/_HTSeq.pxd
-	$(CYTHON) HTSeq/_HTSeq.pyx -o _HTSeq.c
+	$(CYTHON) -3 HTSeq/_HTSeq.pyx -o _HTSeq.c
    
 StepVector_wrap.cxx ../HTSeq/StepVector.py: StepVector.i AutoPyObjPtr.i step_vector.h
-	$(SWIG) -Wall -c++ -python StepVector.i 
+	$(SWIG) -Wall -c++ -python -py3 StepVector.i 
+	
+	# Swig doesn't work perfectly with python3 yet
+	2to3 -w StepVector.py
+	
 	mv StepVector.py ../HTSeq
 

--- a/test/test.py
+++ b/test/test.py
@@ -9,28 +9,28 @@ import HTSeq
 os.chdir( "example_data" )
 
 def test_rst_file( filename ):
-   print "Doctest of %s:" % os.path.basename( filename )
+   print("Doctest of %s:" % os.path.basename( filename ))
    (failure_count, test_count) = doctest.testfile( 
       os.path.join( "..", "doc", filename ), module_relative=False )
 
    if failure_count == 0:
-      print "All %d tests passed." % test_count
+      print("All %d tests passed." % test_count)
       return True
    else:   
-      print "%d of %d tests failed." % (failure_count, test_count)
+      print("%d of %d tests failed." % (failure_count, test_count))
       return False
 
 ok = True
 if len(sys.argv) == 1:
    for fn in glob.glob( "../doc/*.rst" ):
       ok &= test_rst_file( os.path.basename( fn ) )
-      print
+      print()
    if not ok:
-      print "Not all tests passed."
+      print("Not all tests passed.")
       exit( 1 )
 elif len(sys.argv) == 2:
    test_rst_file( sys.argv[1] )
 else:
-   print "Wrong usage"
-   print "Call without arguments to run all doctest, or with the (base) name"
-   print "of one rst file from the doc directory to run doctest on it."
+   print("Wrong usage")
+   print("Call without arguments to run all doctest, or with the (base) name")
+   print("of one rst file from the doc directory to run doctest on it.")

--- a/test/tss_test.py
+++ b/test/tss_test.py
@@ -8,28 +8,28 @@ sys.path.insert( 0, os.path.join( os.getcwd(), build_dir ) )
 import HTSeq
 os.chdir( "example_data" )
 
-print "TSS test, scheme 1"
-execfile( os.path.join( "..", "doc", "tss1.py" ) )
+print("TSS test, scheme 1")
+exec(compile(open( os.path.join( "..", "doc", "tss1.py" ) ).read(), os.path.join( "..", "doc", "tss1.py" ), 'exec'))
 profile1 = profile.copy()
-print "finished"
+print("finished")
 
-print "TSS test, scheme 2"
-execfile( os.path.join( "..", "doc", "tss2.py" ) )
+print("TSS test, scheme 2")
+exec(compile(open( os.path.join( "..", "doc", "tss2.py" ) ).read(), os.path.join( "..", "doc", "tss2.py" ), 'exec'))
 profile2 = profile.copy()
-print "finished",
+print("finished", end=' ')
 
 if ( profile2 == profile1 ).all():
-   print "and matches result from scheme 1."
+   print("and matches result from scheme 1.")
 else:   
-   print "and differs to result from scheme 1!  <<<!!!>>>"
+   print("and differs to result from scheme 1!  <<<!!!>>>")
 
-print "TSS test, scheme 3"
-execfile( os.path.join( "..", "doc", "tss3.py" ) )
+print("TSS test, scheme 3")
+exec(compile(open( os.path.join( "..", "doc", "tss3.py" ) ).read(), os.path.join( "..", "doc", "tss3.py" ), 'exec'))
 profile3 = profile.copy()
-print "finished",
+print("finished", end=' ')
 
 if ( profile3 == profile1 ).all():
-   print "and matches result from scheme 1."
+   print("and matches result from scheme 1.")
 else:   
-   print "and differs to result from scheme 1!  <<<!!!>>>"
+   print("and differs to result from scheme 1!  <<<!!!>>>")
 


### PR DESCRIPTION
Currently linux distributions are slightly changing to python3 as default python interpreter. I think it would be of great interest to have HTSeq compatible with python3 as well. I've been trying to accomplish this and I partially succeeded.

This PR changed some of the code to make it compile/build with python3, requiring `2to3` and `swig` (3.0.9), both available via conda. However, when I import `HTSeq` into python3 I get the follwing error which I can't resolve: `ImportError: No module named 'StepVector'`

However, when I cd into ~/.local/lib/python3.4/site-packages/HTSeq-0.6.2-py3.4-linux-x86_64.egg/HTSeq/ and I run `python3` where I run `import HTSeq`, HTSeq succesfully loads into python3. I know I am close, but I'm afraid I need some help for the finishing touch.
