### PR TITLE
Travis CI cleanup for python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
-lllanguage: python
+dist: trusty
+
+sudo: required
+
+notifications:
+  email: false
+
+language: python
 
 python:
   - 2.7
-#  - "3.2"
-#  - "3.3"
-#  - "3.4"
-#  - "3.5"
 
 env:
  - CC=gcc-5 SWIG=swig3.0
+ - CC=gcc SWIG=swig3.0
 
 addons:
   apt:
@@ -19,40 +23,56 @@ addons:
      - g++-5
 
 before_install:
-#  - sudo add-apt-repository ppa:rosmo/swig3.0.7 -y
-#  - sudo apt-get -qq update
-#  - sudo apt-get install -y swig3.0
-#  - virtualenv -p python .venv
-  - python --version
-  - export PYTHON_VERSION=$(python --version 2>&1 | grep -o -E ' ([^ \.]+.[^\.]+)')
-  - echo "-> "$PYTHON_VERSION
+  - sudo add-apt-repository ppa:nschloe/swig-backports -y
+  - sudo apt-get -qq update
+  - sudo apt-get install -y swig3.0
 
-  - export PYTHON_VERSION="2.7"
-  - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-  #- if [[ "$PYTHON_VERSION" == "2.7" ]]; then
-  #    wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-  #  else
-  #    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  #  fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-  # Add conda forge
-  - conda config --add channels conda-forge 
-
-  - conda create -q -n htseq-dependencies python=2.7 swig=3.0.12 cython flake8 numpy
-  - source activate htseq-dependencies
-
-#  - source .venv/bin/activate
-#  - pip install numpy cython flake8
-  - ./build_it
-  - cd src ; make ; cd ..
-  - python setup.py install
-
+install:
+  - pip install Cython
+  - pip install numpy
+  - pip install pysam
+  - pip install matplotlib
+  - bash ./build_it
+ 
 script:
-  - python setup.py test
-  - cd "$TRAVIS_BUILD_DIR" && ./scripts/flake8.sh
+  - python test/test.py
+
+# CODE FROM YOURI
+#before_install:
+##  - sudo add-apt-repository ppa:rosmo/swig3.0.7 -y
+##  - sudo apt-get -qq update
+##  - sudo apt-get install -y swig3.0
+##  - virtualenv -p python .venv
+#  - python --version
+#  - export PYTHON_VERSION=$(python --version 2>&1 | grep -o -E ' ([^ \.]+.[^\.]+)')
+#  - echo "-> "$PYTHON_VERSION
+#
+#  - export PYTHON_VERSION="2.7"
+#  - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+#  #- if [[ "$PYTHON_VERSION" == "2.7" ]]; then
+#  #    wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+#  #  else
+#  #    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+#  #  fi
+#  - bash miniconda.sh -b -p $HOME/miniconda
+#  - export PATH="$HOME/miniconda/bin:$PATH"
+#  - hash -r
+#  - conda config --set always_yes yes --set changeps1 no
+#  - conda update -q conda
+#  # Useful for debugging any issues with conda
+#  - conda info -a
+#  # Add conda forge
+#  - conda config --add channels conda-forge 
+#
+#  - conda create -q -n htseq-dependencies python=2.7 swig=3.0.12 cython flake8 numpy
+#  - source activate htseq-dependencies
+#
+##  - source .venv/bin/activate
+##  - pip install numpy cython flake8
+#  - ./build_it
+#  - cd src ; make ; cd ..
+#  - python setup.py install
+#
+#script:
+#  - python setup.py test
+#  - cd "$TRAVIS_BUILD_DIR" && ./scripts/flake8.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,16 @@ notifications:
 language: python
 
 python:
-  - 2.7
+  - "2.7"
 
 env:
- - CC=gcc-5 SWIG=swig3.0
- - CC=gcc SWIG=swig3.0
+ global:
+  - SWIG=swig3.0
+ matrix:
+  - CC=gcc-5 PYSAM_VERSION='pysam==0.9.0'
+  - CC=gcc PYSAM_VERSION='pysam==0.9.0'
+  - CC=gcc-5 PYSAM_VERSION='pysam'
+  - CC=gcc PYSAM_VERSION='pysam'
 
 addons:
   apt:
@@ -30,49 +35,9 @@ before_install:
 install:
   - pip install Cython
   - pip install numpy
-  - pip install pysam
+  - pip install "$PYSAM_VERSION"
   - pip install matplotlib
   - bash ./build_it
  
 script:
   - python test/test.py
-
-# CODE FROM YOURI
-#before_install:
-##  - sudo add-apt-repository ppa:rosmo/swig3.0.7 -y
-##  - sudo apt-get -qq update
-##  - sudo apt-get install -y swig3.0
-##  - virtualenv -p python .venv
-#  - python --version
-#  - export PYTHON_VERSION=$(python --version 2>&1 | grep -o -E ' ([^ \.]+.[^\.]+)')
-#  - echo "-> "$PYTHON_VERSION
-#
-#  - export PYTHON_VERSION="2.7"
-#  - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-#  #- if [[ "$PYTHON_VERSION" == "2.7" ]]; then
-#  #    wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-#  #  else
-#  #    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-#  #  fi
-#  - bash miniconda.sh -b -p $HOME/miniconda
-#  - export PATH="$HOME/miniconda/bin:$PATH"
-#  - hash -r
-#  - conda config --set always_yes yes --set changeps1 no
-#  - conda update -q conda
-#  # Useful for debugging any issues with conda
-#  - conda info -a
-#  # Add conda forge
-#  - conda config --add channels conda-forge 
-#
-#  - conda create -q -n htseq-dependencies python=2.7 swig=3.0.12 cython flake8 numpy
-#  - source activate htseq-dependencies
-#
-##  - source .venv/bin/activate
-##  - pip install numpy cython flake8
-#  - ./build_it
-#  - cd src ; make ; cd ..
-#  - python setup.py install
-#
-#script:
-#  - python setup.py test
-#  - cd "$TRAVIS_BUILD_DIR" && ./scripts/flake8.sh

--- a/HTSeq/__init__.py
+++ b/HTSeq/__init__.py
@@ -974,7 +974,8 @@ class BAM_Reader( object ):
            raise TypeError, "Use a HTSeq.GenomicInterval to access regions within .bam-file!"        
         if self.sf is None:
            self.sf = pysam.Samfile( self.filename, "rb" )
-           if not self.sf._hasIndex():
+           # NOTE: pysam 0.9 has renames _hasIndex into has_index
+           if (hasattr(self.sf, '_hasIndex') and (not self.sf._hasIndex())) or (not self.sf.has_index()):
               raise ValueError, "The .bam-file has no index, random-access is disabled!"
         for pa in self.sf.fetch( iv.chrom, iv.start+1, iv.end ):
             yield SAM_Alignment.from_pysam_AlignedRead( pa, self.sf )

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/iosonofabio/htseq.svg?branch=master)](https://travis-ci.org/iosonofabio/htseq)
+[![Build Status](https://travis-ci.org/simon-anders/htseq.svg?branch=master)](https://travis-ci.org/simon-anders/htseq)
 
 HTSeq is a Python library to facilitate processing and analysis of data from 
 high-throughput sequencing (HTS) experiments. 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/iosonofabio/htseq.svg?branch=master)](https://travis-ci.org/iosonofabio/htseq)
+
 HTSeq is a Python library to facilitate processing and analysis of data from 
 high-throughput sequencing (HTS) experiments. 
 

--- a/doc/tour.rst
+++ b/doc/tour.rst
@@ -138,9 +138,8 @@ If you have `matplotlib`_ installed, you can plot these numbers.
 
 .. doctest::
 
-   >>> from matplotlib import pyplot      
-   >>> pyplot.plot( qualsum / nreads )    #doctest:+ELLIPSIS
-   [<matplotlib.lines.Line2D object at 0x...>]
+   >>> from matplotlib import pyplot      #doctest:+SKIP
+   >>> pyplot.plot( qualsum / nreads )    #doctest:+SKIP
    >>> pyplot.show()                      #doctest:+SKIP 
 
 .. image:: qualplot.png
@@ -373,8 +372,7 @@ We can plot an excerpt of this with:
 
 .. doctest::
 
-   >>> pyplot.plot( list( cvg[ HTSeq.GenomicInterval( "III", 200000, 500000, "+" ) ] ) )     #doctest:+ELLIPSIS
-   [<matplotlib.lines.Line2D object at 0x...>]
+   >>> pyplot.plot( list( cvg[ HTSeq.GenomicInterval( "III", 200000, 500000, "+" ) ] ) )     #doctest:+SKIP
    
 However, a proper genome browser gives a better impression of the data. The following commands
 write two BedGraph (Wiggle) files, one for the plus and one for the minus strands::
@@ -429,10 +427,10 @@ We can query the GenomicArrayOfSets, as before:
 .. doctest::
 
    >>> for iv, val in gas[ read_iv ].steps():
-   ...    print iv, val
-   chr1:[450,510)/. set(['A'])
-   chr1:[510,640)/. set(['A', 'B'])
-   chr1:[640,800)/. set(['B'])
+   ...    print iv, sorted(val)
+   chr1:[450,510)/. ['A']
+   chr1:[510,640)/. ['A', 'B']
+   chr1:[640,800)/. ['B']
 
 The interval has been subdivided into three pieces, corresponding to the three different sets that it overlaps,
 namely first only A, then A and B, and finally only B.
@@ -445,16 +443,16 @@ form the set union of the three reported sets, using Python's set union operator
    >>> fset = set()
    >>> for iv, val in gas[ read_iv ].steps():
    ...    fset |= val
-   >>> print fset
-   set(['A', 'B'])
+   >>> print sorted(fset)
+   ['A', 'B']
 
 Experienced Python developers will recognize that the ``for`` loop can be replaced with a single line
 using a generator comprehension and the ``reduce`` function:
 
 .. doctest::
 
-   >>> reduce( set.union, ( val for iv, val in gas[ read_iv ].steps() ) )
-   set(['A', 'B'])
+   >>> sorted(set.union(*[val for iv, val in gas[ read_iv ].steps()]))
+   ['A', 'B']
 
 We will come back to the constructs in the next section, after a brief detour on how to read GTF files.
 
@@ -540,9 +538,13 @@ The last column (the attributes) is parsed and presented as a dict:
 
 .. doctest::
 
-   >>> feature.attr    #doctest:+NORMALIZE_WHITESPACE
-   {'exon_number': '1', 'gene_id': 'R0030W', 'transcript_name': 'RAF1', 
-   'transcript_id': 'R0030W', 'protein_id': 'R0030W', 'gene_name': 'RAF1'}
+   >>> sorted(feature.attr.items())    #doctest:+NORMALIZE_WHITESPACE
+   [('exon_number', '1'),
+    ('gene_id', 'R0030W'),
+    ('gene_name', 'RAF1'),
+    ('protein_id', 'R0030W'),
+    ('transcript_id', 'R0030W'),
+    ('transcript_name', 'RAF1')] 
    
 The very first attribute in this column is usually some kind of ID, hence it is
 stored in the slot :attr:`name <GenomicFeature.name>`:
@@ -574,11 +576,11 @@ Assume we have a read covering this interval::
 Its left half covers two genes (YCL058C, YCL058W-A), but its right half only
 YCL058C because YCL058W-A end in the middle of the read::
 
-   >>> list( exons[iv].steps() )   #doctest:+NORMALIZE_WHITESPACE
+   >>> [(st[0], sorted(st[1])) for st in exons[iv].steps()]   #doctest:+NORMALIZE_WHITESPACE
    [(<GenomicInterval object 'III', [23850,23925), strand '.'>,
-        set(['YCL058C', 'YCL058W-A'])),
+        ['YCL058C', 'YCL058W-A']),
     (<GenomicInterval object 'III', [23925,23950), strand '.'>, 
-        set(['YCL058C']))]
+        ['YCL058C'])]
 
 Assuming the transcription boundaries in our GTF file to be correct, we may conclude
 that this read is from the gene that appears in both steps and not from the one that

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,7 @@
 CYTHON=cython
-SWIG=swig
+ifndef SWIG
+	SWIG=swig
+endif
 
 all: StepVector_wrap.cxx ../HTSeq/StepVector.py _HTSeq.c
 
@@ -10,6 +12,7 @@ _HTSeq.c: HTSeq/_HTSeq.pyx HTSeq/_HTSeq.pxd
 	$(CYTHON) HTSeq/_HTSeq.pyx -o _HTSeq.c
    
 StepVector_wrap.cxx ../HTSeq/StepVector.py: StepVector.i AutoPyObjPtr.i step_vector.h
-	$(SWIG) -Wall -c++ -python -classic StepVector.i 
+	#$(SWIG) -Wall -c++ -python -classic StepVector.i 
+	$(SWIG) -Wall -c++ -python StepVector.i 
 	mv StepVector.py ../HTSeq
 


### PR DESCRIPTION
I cleaned up the mechamisms for continuous integration (travis CI) to support:

- python 2.7
- gcc 4.8+ or 5 (gcc 6 should work but is not included in the CI matrix yet)
- swig 3.0.8+
- pysam 0.9 or latest (currently 0.10)

Pysam introduced a number of non-backward compatible API changes around versions 0.8.4-0.9, so supporting pysam<0.9.0 requires special, deprecated code. I am in favour of deprecating those cases and start supporting from pysam 0.9 onwards.

I made similar changes for the python 3 branch that are addressed in pull request #15.

This addresses issues #13 and #4 .