### PR TITLE
Matplotlib >=1.5 uses Normalize, cover both cases for now

### DIFF
--- a/HTSeq/scripts/qa.py
+++ b/HTSeq/scripts/qa.py
@@ -20,6 +20,12 @@ def main():
    matplotlib.use('PDF')
    from matplotlib import pyplot
 
+   # Matplotlib <1.5 uses normalize, so this block will be deprecated
+   try:
+       from matplotlib.pyplot import Normalize
+    except ImportError:
+        from matplotlib.pyplot import normalize as Normalize
+
 
    # **** Parse command line ****
 
@@ -201,14 +207,14 @@ def main():
 
       pyplot.subplot( 223 )
       pyplot.pcolor( qual_arr_U_n.T ** gamma, cmap=pyplot.cm.Greens,
-	  norm=pyplot.normalize( 0, 1 ) )
+	  norm=Normalize( 0, 1 ) )
       pyplot.axis( (0, readlen-1, 0, max_qual+1 ) )
       pyplot.xlabel( "position in read" )
       pyplot.ylabel( "base-call quality score" )
 
       pyplot.subplot( 224 )
       pyplot.pcolor( qual_arr_A_n.T ** gamma, cmap=pyplot.cm.Greens,
-	   norm=pyplot.normalize( 0, 1 ) )
+	   norm=Normalize( 0, 1 ) )
       pyplot.axis( (0, readlen-1, 0, max_qual+1 ) )
       pyplot.xlabel( "position in read" )
 
@@ -221,7 +227,7 @@ def main():
 
       pyplot.subplot( 212 )
       pyplot.pcolor( qual_arr_U_n.T ** gamma, cmap=pyplot.cm.Greens,
-	  norm=pyplot.normalize( 0, 1 ) )
+	  norm=Normalize( 0, 1 ) )
       pyplot.axis( (0, readlen-1, 0, max_qual+1 ) )
       pyplot.xlabel( "position in read" )
       pyplot.ylabel( "base-call quality score" )


### PR DESCRIPTION
This fix should work for both mpl versions. Overrides PR #3 (which is non backwards-compatible) and addresses issue #2 .