### PR TITLE
SAM file optional field B support

### DIFF
--- a/src/HTSeq/_HTSeq.pyx
+++ b/src/HTSeq/_HTSeq.pyx
@@ -1174,6 +1174,11 @@ cdef _parse_SAM_optional_field_value( str field ):
       return field[5:]
    elif field[3] == 'H':
       return int( field[5:], 16 )
+   elif field[3] == 'B':
+      if field[5] == 'f': 
+         return numpy.array( field[7:].split(','), float )
+      else:
+         return numpy.array( field[7:].split(','), int )
    else:
       raise ValueError, "SAM optional field with illegal type letter '%s'" % field[2]
 


### PR DESCRIPTION
The SAM file specification includes an optional field B that we currently do not support:

https://samtools.github.io/hts-specs/SAMv1.pdf, page 6.

This PR adds a first, tentative support for that case.

NOTE: this should really be profiled to make sure we are not slowing down too much in that case.