### PR TITLE
Passing memmap_dir on to ChromVector.create

### DIFF
--- a/python2/src/HTSeq/_HTSeq.pyx
+++ b/python2/src/HTSeq/_HTSeq.pyx
@@ -576,7 +576,9 @@ cdef class GenomicArray(object):
                                    self.storage, self.memmap_dir)
         else:
             self.chrom_vectors[chrom] = {
-                strand_nostrand:  ChromVector.create(iv, self.typecode, self.storage)}
+                strand_nostrand:  ChromVector.create(iv, self.typecode,
+                                                     self.storage,
+                                                     self.memmap_dir)}
 
     def __reduce__(self):
         return (_GenomicArray_unpickle, (self.stranded, self.typecode, self.chrom_vectors))

--- a/python3/src/HTSeq/_HTSeq.pyx
+++ b/python3/src/HTSeq/_HTSeq.pyx
@@ -579,7 +579,9 @@ cdef class GenomicArray(object):
                                    self.storage, self.memmap_dir)
         else:
             self.chrom_vectors[chrom] = {
-                strand_nostrand:  ChromVector.create(iv, self.typecode, self.storage)}
+                strand_nostrand:  ChromVector.create(iv, self.typecode,
+                                                     self.storage,
+                                                     self.memmap_dir)}
 
     def __reduce__(self):
         return (_GenomicArray_unpickle, (self.stranded, self.typecode, self.chrom_vectors))


### PR DESCRIPTION
During unstranded GenomicArray construction,
the `memmap_dir` option was not passed on to
ChromVector.create. Therefore, the '.nmm' files were always
created in the current folder instead of `memmap_dir`.