### PR TITLE
add `check_sq` option `BAM_Reader`

### DIFF
--- a/python2/HTSeq/__init__.py
+++ b/python2/HTSeq/__init__.py
@@ -943,11 +943,12 @@ class WiggleReader( FileOrSequence ):
             
 class BAM_Reader( object ):
 
-    def __init__( self, filename ):
+    def __init__( self, filename, check_sq=True):
         global pysam
         self.filename = filename
         self.sf = None  # This one is only used by __getitem__
         self.record_no = -1
+        self.check_sq = check_sq
         try:
            import pysam
         except ImportError:
@@ -955,7 +956,7 @@ class BAM_Reader( object ):
            raise
     
     def __iter__( self ):
-        sf = pysam.Samfile(self.filename, "rb")
+        sf = pysam.Samfile(self.filename, "rb", check_sq=self.check_sq)
         self.record_no = 0
         for pa in sf:
             #yield SAM_Alignment.from_pysam_AlignedRead( pa, sf )
@@ -963,7 +964,7 @@ class BAM_Reader( object ):
             self.record_no += 1
     
     def fetch( self, reference = None, start = None, end = None, region = None ):
-        sf = pysam.Samfile(self.filename, "rb")
+        sf = pysam.Samfile(self.filename, "rb", check_sq=self.check_sq)
         self.record_no = 0
         try:
            for pa in sf.fetch( reference, start, end, region ):
@@ -988,7 +989,7 @@ class BAM_Reader( object ):
         if not isinstance( iv, GenomicInterval ):
            raise TypeError, "Use a HTSeq.GenomicInterval to access regions within .bam-file!"        
         if self.sf is None:
-           self.sf = pysam.Samfile( self.filename, "rb" )
+           self.sf = pysam.Samfile( self.filename, "rb", check_sq=self.check_sq)
            # NOTE: pysam 0.9 has renames _hasIndex into has_index
            if (hasattr(self.sf, '_hasIndex') and (not self.sf._hasIndex())) or (not self.sf.has_index()):
               raise ValueError, "The .bam-file has no index, random-access is disabled!"
@@ -996,7 +997,7 @@ class BAM_Reader( object ):
             yield SAM_Alignment.from_pysam_AlignedRead( pa, self.sf )
     
     def get_header_dict( self ):
-       sf = pysam.Samfile(self.filename, "rb")
+       sf = pysam.Samfile(self.filename, "rb", check_sq=self.check_sq)
        return sf.header
     
                

--- a/python3/HTSeq/__init__.py
+++ b/python3/HTSeq/__init__.py
@@ -993,11 +993,12 @@ class WiggleReader(FileOrSequence):
 
 class BAM_Reader(object):
 
-    def __init__(self, filename):
+    def __init__(self, filename, check_sq=True):
         global pysam
         self.filename = filename
         self.sf = None  # This one is only used by __getitem__
         self.record_no = -1
+        self.check_sq = check_sq
         try:
             import pysam
         except ImportError:
@@ -1006,7 +1007,7 @@ class BAM_Reader(object):
             raise
 
     def __iter__(self):
-        sf = pysam.Samfile(self.filename, "rb")
+        sf = pysam.Samfile(self.filename, "rb", check_sq=self.check_sq)
         self.record_no = 0
         for pa in sf:
             # yield SAM_Alignment.from_pysam_AlignedRead( pa, sf )
@@ -1014,7 +1015,7 @@ class BAM_Reader(object):
             self.record_no += 1
 
     def fetch(self, reference=None, start=None, end=None, region=None):
-        sf = pysam.Samfile(self.filename, "rb")
+        sf = pysam.Samfile(self.filename, "rb", check_sq=self.check_sq)
         self.record_no = 0
         try:
             for pa in sf.fetch(reference, start, end, region):
@@ -1041,7 +1042,7 @@ class BAM_Reader(object):
             raise TypeError(
                 "Use a HTSeq.GenomicInterval to access regions within .bam-file!")
         if self.sf is None:
-            self.sf = pysam.Samfile(self.filename, "rb")
+            self.sf = pysam.Samfile(self.filename, "rb", check_seq=self.check_sq)
             # NOTE: pysam 0.9 has renames _hasIndex into has_index
             if (hasattr(self.sf, '_hasIndex') and (not self.sf._hasIndex())) or (not self.sf.has_index()):
                 raise ValueError(
@@ -1050,7 +1051,7 @@ class BAM_Reader(object):
             yield SAM_Alignment.from_pysam_AlignedRead(pa, self.sf)
 
     def get_header_dict(self):
-        sf = pysam.Samfile(self.filename, "rb")
+        sf = pysam.Samfile(self.filename, "rb", check_sq=self.check_sq)
         return sf.header
 
 


### PR DESCRIPTION
BAM files created by some programs
(e.g., PacBio's CCS) lack the SQ flag.
They can still be read by `pysam` using
the `check_sq=False` flag. This commit
creates an option to use that flag when
using `HTSeq.BAM_Reader`.