### PR TITLE
[FIX] Python 3.7 StopIteration support

### DIFF
--- a/python3/HTSeq/__init__.py
+++ b/python3/HTSeq/__init__.py
@@ -407,6 +407,8 @@ class FastqReader(FileOrSequence):
             seq = next(fin)
             id2 = next(fin)
             qual = next(fin)
+            except StopIteration as e:
+                return
             if qual == "":
                 if id1 != "":
                     warnings.warn(


### PR DESCRIPTION
Changed in version 3.7: Enable PEP 479 for all code by default: a StopIteration error raised in a generator is transformed into a RuntimeError.

A simply catch and return is the common fix for this.